### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -363,7 +363,17 @@ function displayTVPoster(id, posterUrl, title = null) {
         altText = `${row.cells[1].textContent} TV show poster`;
       }
     }
-    cell.innerHTML = `<img src="${posterUrl}" alt="${altText}" style="width: 60px; max-height: 90px; object-fit: cover; border-radius: 4px;" loading="lazy">`;
+    // Construct image via DOM methods to avoid XSS
+    cell.innerHTML = '';
+    const img = document.createElement('img');
+    img.src = posterUrl;
+    img.alt = altText;
+    img.style.width = '60px';
+    img.style.maxHeight = '90px';
+    img.style.objectFit = 'cover';
+    img.style.borderRadius = '4px';
+    img.loading = 'lazy';
+    cell.appendChild(img);
   }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/chambies2015/OmniTrackr/security/code-scanning/3](https://github.com/chambies2015/OmniTrackr/security/code-scanning/3)

**General Fix:**  
To prevent XSS, never insert untrusted data via string interpolation into `innerHTML`. Instead, either (1) use appropriate escaping for HTML attribute values before inclusion, or (2) use DOM APIs to create elements and set their attributes/properties directly, bypassing `innerHTML`.

**Best Fix:**  
The most robust solution is to construct the `<img>` element using `document.createElement`, set its `src` and `alt` via `.src` and `.alt`, and insert it into the cell using `cell.replaceChildren(img)`. This fully avoids HTML interpolation and ensures values are set as literals, not HTML-parsed content.

**Where to change:**  
Edit the `displayTVPoster` function, specifically in the currently tainted region:
- Instead of setting `cell.innerHTML = ...` with string interpolation (line 366), clear the cell and append a newly created `<img>` element.

**What is needed:**  
- Change line 366 as above.
- No new dependencies required.
- No imports needed for standard DOM APIs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
