### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -10,6 +10,16 @@ let notificationCountInterval = null;
 const posterFetchInProgress = new Set();
 const posterFetchQueue = new Map(); // title+year -> Promise
 
+// Utility HTML escaping function
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 // Tab switching functionality
 function switchTab(tabName) {
   // Update tab buttons
@@ -131,6 +141,7 @@ function displayMoviePoster(id, posterUrl, title = null) {
         altText = `${row.cells[1].textContent} movie poster`;
       }
     }
+    altText = escapeHtml(altText);
     cell.innerHTML = `<img src="${posterUrl}" alt="${altText}" style="width: 60px; max-height: 90px; object-fit: cover; border-radius: 4px;" loading="lazy">`;
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/chambies2015/OmniTrackr/security/code-scanning/2](https://github.com/chambies2015/OmniTrackr/security/code-scanning/2)

To fix the vulnerability:
- Escape any special HTML characters in the `altText` variable before including it in an HTML string that is assigned to `innerHTML`.
- Implement an escaping function (if one does not exist) to safely encode metacharacters (`&`, `<`, `>`, `"`, `'`, `/`).
- Apply the escaping function to the `altText` before template interpolation.
- The most localized place to do this is inside `displayMoviePoster` function, immediately before the `cell.innerHTML = ...` line.
- No need to escape `posterUrl` (assuming it is not controlled by untrusted users; if it could be, similar sanitation is needed there, but that's not part of the flagged path).
- If a utility escape function doesn't already exist in app/static/app.js, define one at file scope.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
