### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Python Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/chambies2015/OmniTrackr/security/code-scanning/1](https://github.com/chambies2015/OmniTrackr/security/code-scanning/1)

To address the warning and secure the workflow, explicitly add a `permissions` block. The most future-proof and minimal solution is to add `permissions: contents: read` at the top workflow level (just after the `name:` line and before `on:`), which applies to all jobs unless overridden. This is sufficient for CI jobs that only check out and test code, which is the case here. No additional packages or imports are required. The only change is to the YAML at the root of `.github/workflows/tests.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
